### PR TITLE
fix: profile页未显示关注状态

### DIFF
--- a/lib/http/api.dart
+++ b/lib/http/api.dart
@@ -97,8 +97,8 @@ class Api {
   // 操作用户关系
   static const String relationMod = '/x/relation/modify';
 
-  // 相互关系查询
-  static const String relationSearch = '/x/space/wbi/acc/relation';
+  // 相互关系查询 // 失效
+  // static const String relationSearch = '/x/space/wbi/acc/relation';
 
   // 评论列表
   // https://api.bilibili.com/x/v2/reply/main?csrf=6e22efc1a47225ea25f901f922b5cfdd&mode=3&oid=254175381&pagination_str=%7B%22offset%22:%22%22%7D&plat=1&seek_rpid=0&type=11

--- a/lib/http/user.dart
+++ b/lib/http/user.dart
@@ -250,31 +250,43 @@ class UserHttp {
       return {'status': false, 'msg': res.data['message']};
     }
   }
-
-  // 相互关系查询
-  static Future relationSearch(int mid) async {
-    Map params = await WbiSign().makSign({
-      'mid': mid,
-      'token': '',
-      'platform': 'web',
-      'web_location': 1550101,
-    });
+  static Future hasFollow(int mid) async {
     var res = await Request().get(
-      Api.relationSearch,
+      Api.hasFollow,
       data: {
-        'mid': mid,
-        'w_rid': params['w_rid'],
-        'wts': params['wts'],
+        'fid': mid,
       },
     );
     if (res.data['code'] == 0) {
-      // relation 主动状态
-      // 被动状态
       return {'status': true, 'data': res.data['data']};
     } else {
       return {'status': false, 'msg': res.data['message']};
     }
   }
+  // // 相互关系查询
+  // static Future relationSearch(int mid) async {
+  //   Map params = await WbiSign().makSign({
+  //     'mid': mid,
+  //     'token': '',
+  //     'platform': 'web',
+  //     'web_location': 1550101,
+  //   });
+  //   var res = await Request().get(
+  //     Api.relationSearch,
+  //     data: {
+  //       'mid': mid,
+  //       'w_rid': params['w_rid'],
+  //       'wts': params['wts'],
+  //     },
+  //   );
+  //   if (res.data['code'] == 0) {
+  //     // relation 主动状态
+  //     // 被动状态
+  //     return {'status': true, 'data': res.data['data']};
+  //   } else {
+  //     return {'status': false, 'msg': res.data['message']};
+  //   }
+  // }
 
   // 搜索历史记录
   static Future searchHistory(

--- a/lib/pages/member/controller.dart
+++ b/lib/pages/member/controller.dart
@@ -116,16 +116,28 @@ class MemberController extends GetxController {
   Future relationSearch() async {
     if (userInfo == null) return;
     if (mid == ownerMid) return;
-    var res = await UserHttp.relationSearch(mid);
+    var res = await UserHttp.hasFollow(mid);
     if (res['status']) {
-      attribute.value = res['data']['relation']['attribute'];
-      attributeText.value = attribute.value == 0
-          ? '关注'
-          : attribute.value == 2
-              ? '已关注'
-              : attribute.value == 6
-                  ? '已互粉'
-                  : '已拉黑';
+      attribute.value = res['data']['attribute'];
+      switch (attribute.value) {
+        case 1:
+          attributeText.value = '悄悄关注';
+          break;
+        case 2:
+          attributeText.value = '已关注';
+          break;
+        case 6:
+          attributeText.value = '已互关';
+          break;
+        case 128:
+          attributeText.value = '已拉黑';
+          break;
+        default:
+          attributeText.value = '关注';
+      }
+      if (res['data']['special'] == 1) {
+        attributeText.value += 'SP';
+      }
     }
   }
 


### PR DESCRIPTION
经测试，原接口会返回{"code":-403,"message":"访问权限不足","ttl":1}，所以统一为hasFollow接口，并收录了更多的状态文本