### PR TITLE
Refactor danmaku controller

### DIFF
--- a/lib/pages/danmaku/controller.dart
+++ b/lib/pages/danmaku/controller.dart
@@ -5,7 +5,6 @@ import 'package:pilipala/plugin/pl_player/index.dart';
 class PlDanmakuController {
   PlDanmakuController(this.cid);
   final int cid;
-  late Duration videoDuration;
   Map<int,List<DanmakuElem>> dmSegMap = {};
   // 已请求的段落标记
   List<bool> requestedSeg = [];
@@ -14,9 +13,9 @@ class PlDanmakuController {
 
   static int SEGMENT_LENGTH = 60 * 6 * 1000;
 
-  void initiate(int progress) {
+  void initiate(int videoDuration, int progress) {
     if (requestedSeg.isEmpty) {
-      int segCount = (videoDuration.inSeconds / (60 * 6)).ceil();
+      int segCount = (videoDuration / SEGMENT_LENGTH).ceil();
       requestedSeg = List<bool>.generate(segCount, (index) => false);
     }
     queryDanmaku(

--- a/lib/pages/danmaku/controller.dart
+++ b/lib/pages/danmaku/controller.dart
@@ -3,74 +3,57 @@ import 'package:pilipala/models/danmaku/dm.pb.dart';
 import 'package:pilipala/plugin/pl_player/index.dart';
 
 class PlDanmakuController {
-  PlDanmakuController(this.cid, this.playerController);
+  PlDanmakuController(this.cid);
   final int cid;
-  final PlPlayerController playerController;
   late Duration videoDuration;
-  // 按 6min 分段
-  int segCount = 0;
-  List<DmSegMobileReply> dmSegList = [];
+  Map<int,List<DanmakuElem>> dmSegMap = {};
   // 已请求的段落标记
-  List<int> hasrequestSeg = [];
-  int currentSegIndex = 1;
-  int currentDmIndex = 0;
+  List<bool> requestedSeg = [];
 
-  void calcSegment() {
-    dmSegList.clear();
-    // 视频分段数
-    segCount = (videoDuration.inSeconds / (60 * 6)).ceil();
-    dmSegList = List<DmSegMobileReply>.generate(
-        segCount < 1 ? 1 : segCount, (index) => DmSegMobileReply());
-    // 当前分段
-    try {
-      currentSegIndex =
-          (playerController.position.value.inSeconds / (60 * 6)).ceil();
-      currentSegIndex = currentSegIndex < 1 ? 1 : currentSegIndex;
-    } catch (_) {}
+  bool get initiated => requestedSeg.isNotEmpty;
+
+  static int SEGMENT_LENGTH = 60 * 6 * 1000;
+
+  void initiate(int progress) {
+    if (requestedSeg.isEmpty) {
+      int segCount = (videoDuration.inSeconds / (60 * 6)).ceil();
+      requestedSeg = List<bool>.generate(segCount, (index) => false);
+    }
+    queryDanmaku(
+        calcSegment(progress)
+    );
   }
 
-  Future<List<DmSegMobileReply>> queryDanmaku() async {
-    // dmSegList.clear();
+  void dispose() {
+    dmSegMap.clear();
+    requestedSeg.clear();
+  }
+
+  int calcSegment(int progress) {
+    return progress ~/ SEGMENT_LENGTH;
+  }
+
+  void queryDanmaku(int segmentIndex) async {
+    assert(requestedSeg[segmentIndex] == false);
+    requestedSeg[segmentIndex] = true;
     DmSegMobileReply result =
-        await DanmakaHttp.queryDanmaku(cid: cid, segmentIndex: currentSegIndex);
+        await DanmakaHttp.queryDanmaku(cid: cid, segmentIndex: segmentIndex + 1);
     if (result.elems.isNotEmpty) {
-      result.elems.sort((a, b) => (a.progress).compareTo(b.progress));
-      // dmSegList.add(result);
-      currentSegIndex = currentSegIndex < 1 ? 1 : currentSegIndex;
-      dmSegList[currentSegIndex - 1] = result;
+      for (var element in result.elems) {
+        int pos = element.progress ~/ 100;//每0.1秒存储一次
+        if (dmSegMap[pos] == null) {
+          dmSegMap[pos] = [];
+        }
+        dmSegMap[pos]!.add(element);
+      }
     }
-    if (dmSegList.isNotEmpty) {
-      findClosestPositionIndex(playerController.position.value.inMilliseconds);
-    }
-    return dmSegList;
   }
 
-  /// 查询当前最接近的弹幕
-  void findClosestPositionIndex(int position) {
-    int segIndex = (position / (6 * 60 * 1000)).ceil() - 1;
-    if (segIndex < 0) segIndex = 0;
-    List elems = dmSegList[segIndex].elems;
-
-    if (segIndex < dmSegList.length) {
-      int left = 0;
-      int right = elems.length;
-
-      while (left < right) {
-        int mid = (right + left) ~/ 2;
-        var midPosition = elems[mid].progress;
-
-        if (midPosition >= position) {
-          right = mid;
-        } else {
-          left = mid + 1;
-        }
-      }
-
-      currentSegIndex = segIndex;
-      currentDmIndex = right;
-    } else {
-      currentSegIndex = segIndex;
-      currentDmIndex = 0;
+  List<DanmakuElem>? getCurrentDanmaku(int progress) {
+    int segmentIndex = calcSegment(progress);
+    if (!requestedSeg[segmentIndex]) {
+      queryDanmaku(segmentIndex);
     }
+    return dmSegMap[progress ~/ 100];
   }
 }

--- a/lib/pages/danmaku/view.dart
+++ b/lib/pages/danmaku/view.dart
@@ -47,9 +47,9 @@ class _PlDanmakuState extends State<PlDanmaku> {
         PlDanmakuController(widget.cid);
     if (mounted) {
       playerController = widget.playerController;
-      _plDanmakuController.videoDuration = playerController.duration.value;
       if (enableShowDanmaku || playerController.isOpenDanmu.value) {
         _plDanmakuController.initiate(
+            playerController.duration.value.inMilliseconds,
             playerController.position.value.inMilliseconds
         );
       }
@@ -60,6 +60,7 @@ class _PlDanmakuState extends State<PlDanmaku> {
     playerController.isOpenDanmu.listen((p0) {
       if (p0 && !_plDanmakuController.initiated) {
         _plDanmakuController.initiate(
+            playerController.duration.value.inMilliseconds,
             playerController.position.value.inMilliseconds
         );
       }


### PR DESCRIPTION
改用map存储，将同属于100毫秒内的弹幕归入一个元素，无需再排序和二分比较取得，降低时间复杂度与播放时功耗； 
分离PlDanmakuController与playerController的功能，避免代码耦合；
精简用于表示状态的变量与相关逻辑，修复播放完毕后因currentSegIndex永久增加而无法再显示弹幕的错误；
为PlDanmakuController添加dispose()。