### PR TITLE
fix: 非全屏透明appbar无图标、横屏视频竖屏全屏播放时有白色状态栏

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,7 +37,6 @@ void main() async {
       systemNavigationBarColor: Colors.transparent,
       systemNavigationBarDividerColor: Colors.transparent,
       statusBarColor: Colors.transparent,
-      statusBarIconBrightness: Brightness.dark,
     ));
     await Request.setCookie();
     Data.init();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,6 +37,7 @@ void main() async {
       systemNavigationBarColor: Colors.transparent,
       systemNavigationBarDividerColor: Colors.transparent,
       statusBarColor: Colors.transparent,
+      statusBarIconBrightness: Brightness.dark,
     ));
     await Request.setCookie();
     Data.init();

--- a/lib/pages/video/detail/view.dart
+++ b/lib/pages/video/detail/view.dart
@@ -291,7 +291,7 @@ class _VideoDetailPageState extends State<VideoDetailPage>
             appBar: PreferredSize(
               preferredSize: const Size.fromHeight(0),
               child: AppBar(
-                backgroundColor: Theme.of(context).colorScheme.background,
+                backgroundColor: Colors.transparent,
                 elevation: 0,
               ),
             ),


### PR DESCRIPTION
之前修复图标不显示的思路不太对（appbar改成白底），现在改成了透明底但图标显色，更沉浸，顺便修复问题