### PR TITLE
feat: 动态瀑布流横屏支持

### DIFF
--- a/lib/pages/dynamics/view.dart
+++ b/lib/pages/dynamics/view.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:get/get.dart';
 import 'package:hive/hive.dart';
+import 'package:waterfall_flow/waterfall_flow.dart';
 import 'package:pilipala/common/skeleton/dynamic_card.dart';
 import 'package:pilipala/common/widgets/http_error.dart';
 import 'package:pilipala/common/widgets/no_data.dart';
@@ -14,6 +15,8 @@ import 'package:pilipala/pages/main/index.dart';
 import 'package:pilipala/utils/feed_back.dart';
 import 'package:pilipala/utils/storage.dart';
 
+import '../../common/constants.dart';
+import '../../utils/grid.dart';
 import 'controller.dart';
 import 'widgets/dynamic_panel.dart';
 import 'widgets/up_panel.dart';
@@ -269,14 +272,28 @@ class _DynamicsPageState extends State<DynamicsPage>
                             return const NoData();
                           }
                         } else {
-                          return SliverList(
-                            delegate: SliverChildBuilderDelegate(
-                              (context, index) {
-                                return DynamicPanel(item: list[index]);
-                              },
-                              childCount: list.length,
-                            ),
-                          );
+                          return SliverWaterfallFlow.extent(
+                              maxCrossAxisExtent: Grid.maxRowWidth * 2,
+                              //cacheExtent: 0.0,
+                              crossAxisSpacing: StyleString.safeSpace,
+                              mainAxisSpacing: StyleString.safeSpace,
+
+                              /// follow max child trailing layout offset and layout with full cross axis extend
+                              /// last child as loadmore item/no more item in [GridView] and [WaterfallFlow]
+                              /// with full cross axis extend
+                              //  LastChildLayoutType.fullCrossAxisExtend,
+
+                              /// as foot at trailing and layout with full cross axis extend
+                              /// show no more item at trailing when children are not full of viewport
+                              /// if children is full of viewport, it's the same as fullCrossAxisExtend
+                              //  LastChildLayoutType.foot,
+                              lastChildLayoutTypeBuilder: (index) =>
+                                  index == list.length
+                                      ? LastChildLayoutType.foot
+                                      : LastChildLayoutType.none,
+                              children: [
+                                for (var i in list) DynamicPanel(item: i),
+                              ]);
                         }
                       },
                     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1597,7 +1597,7 @@ packages:
     source: hosted
     version: "1.1.0"
   waterfall_flow:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: waterfall_flow
       sha256: "11538b0d890458e55e6248b177732495d20893cfc7e85d7e8dbf4fdce61c9f10"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -140,6 +140,8 @@ dependencies:
   catcher_2: ^1.1.0
   logger: ^2.0.2+1
   path: 1.8.3
+  #瀑布流
+  waterfall_flow: ^3.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
由于动态框的长度不一致，横屏情况下做成瀑布流形式，可以作为一种便捷的适配过渡手段，避免横屏时宽度过大而显示不出多少东西（该commit依赖之前的横屏支持pull request）