### PR TITLE
fix: 日期转换失败导致日志无法显示，新增fatal等级记录，统一日志文件获取

### DIFF
--- a/lib/pages/setting/pages/logs.dart
+++ b/lib/pages/setting/pages/logs.dart
@@ -45,14 +45,19 @@ class _LogsPageState extends State<LogsPage> {
     }).toList();
     List<Map<String, dynamic>> result = [];
     for (String i in contentList) {
-      DateTime? date;
+      dynamic date;
       String body = i
           .split("\n")
           .map((l) {
             if (l.startsWith("Crash occurred on")) {
-              date = DateTime.parse(
-                l.split("Crash occurred on")[1].trim().split('.')[0],
-              );
+              try {
+                date = DateTime.parse(
+                  l.split("Crash occurred on")[1].trim().split('.')[0],
+                );
+              } catch (e) {
+                print(e.toString());
+                date = l.toString();
+              }
               return "";
             }
             return l;

--- a/lib/services/loggeer.dart
+++ b/lib/services/loggeer.dart
@@ -18,12 +18,10 @@ class PiliLogger extends Logger {
   @override
   void log(Level level, dynamic message,
       {Object? error, StackTrace? stackTrace, DateTime? time}) async {
-    if (level == Level.error) {
-      String dir = (await getApplicationDocumentsDirectory()).path;
-      // 创建logo文件
-      final String filename = p.join(dir, ".pili_logs");
+    if (level == Level.error || level == Level.fatal) {
       // 添加至文件末尾
-      await File(filename).writeAsString(
+      File logFile = await getLogsPath();
+      logFile.writeAsString(
         "**${DateTime.now()}** \n $message \n $stackTrace",
         mode: FileMode.writeOnlyAppend,
       );
@@ -35,17 +33,15 @@ class PiliLogger extends Logger {
 Future<File> getLogsPath() async {
   String dir = (await getApplicationDocumentsDirectory()).path;
   final String filename = p.join(dir, ".pili_logs");
-  final file = File(filename);
+  final File file = File(filename);
   if (!await file.exists()) {
-    await file.create();
+    await file.create(recursive: true);
   }
   return file;
 }
 
 Future<bool> clearLogs() async {
-  String dir = (await getApplicationDocumentsDirectory()).path;
-  final String filename = p.join(dir, ".pili_logs");
-  final file = File(filename);
+  final File file = await getLogsPath();
   try {
     await file.writeAsString('');
   } catch (e) {


### PR DESCRIPTION
日志中存在异常日期数据（如有一行 Crash occurred on 2024-02-xxxx，xxxx本应该是日期，却成了某些字母）时，日志无法正常加载