### PR TITLE
fix 默认搜索词无效bug

### DIFF
--- a/lib/pages/search/controller.dart
+++ b/lib/pages/search/controller.dart
@@ -18,6 +18,7 @@ class SSearchController extends GetxController {
   RxList<SearchSuggestItem> searchSuggestList = <SearchSuggestItem>[].obs;
   final _debouncer =
       Debouncer(delay: const Duration(milliseconds: 200)); // 设置延迟时间
+  late bool customSearchHint;
   String hintText = '搜索';
   RxString defaultSearch = ''.obs;
   Box setting = GStrorage.setting;
@@ -32,8 +33,11 @@ class SSearchController extends GetxController {
         onClickKeyword(Get.parameters['keyword']!);
       }
       if (Get.parameters['hintText'] != null) {
+        customSearchHint = true;
         hintText = Get.parameters['hintText']!;
         searchKeyWord.value = hintText;
+      } else {
+        customSearchHint = false;
       }
     }
     historyCacheList = histiryWord.get('cacheList') ?? [];
@@ -44,6 +48,9 @@ class SSearchController extends GetxController {
   void onChange(value) {
     searchKeyWord.value = value;
     if (value == '') {
+      if (customSearchHint) {
+        searchKeyWord.value = hintText;
+      }
       searchSuggestList.value = [];
       return;
     }
@@ -53,7 +60,11 @@ class SSearchController extends GetxController {
   void onClear() {
     if (searchKeyWord.value.isNotEmpty && controller.value.text != '') {
       controller.value.clear();
-      searchKeyWord.value = '';
+      if (customSearchHint) {
+        searchKeyWord.value = hintText;
+      } else {
+        searchKeyWord.value = '';
+      }
       searchSuggestList.value = [];
     } else {
       Get.back();


### PR DESCRIPTION
修复Bug：进入搜索页面，搜索框内输入任意内容，再删光或点击清除按钮，显示出hint文案，再点击搜索，发现不会使用hint的文案进行搜索