### PR TITLE
fix: 修复评论页逻辑错误导致的页面卡死问题

### DIFF
--- a/lib/common/widgets/http_error.dart
+++ b/lib/common/widgets/http_error.dart
@@ -41,7 +41,7 @@ class HttpError extends StatelessWidget {
                   fn!();
                 },
                 style: ButtonStyle(
-                  backgroundColor: MaterialStateProperty.resolveWith((states) {
+                  backgroundColor: WidgetStateProperty.resolveWith((states) {
                     return Theme.of(context).colorScheme.primary.withAlpha(20);
                   }),
                 ),
@@ -52,7 +52,7 @@ class HttpError extends StatelessWidget {
                 ),
               ),
           ],
-        ),
+      ),
       ),
     );
   }

--- a/lib/pages/video/detail/reply/view.dart
+++ b/lib/pages/video/detail/reply/view.dart
@@ -188,7 +188,7 @@ class _VideoReplyPanelState extends State<VideoReplyPanel>
                   if (snapshot.connectionState == ConnectionState.done) {
                     var data = snapshot.data;
                     if (_videoReplyController.replyList.isNotEmpty ||
-                        (data && data['status'])) {
+                        (data != null && data['status'] == true)) {
                       // 请求成功
                       return Obx(
                         () => _videoReplyController.isLoadingMore &&
@@ -247,7 +247,7 @@ class _VideoReplyPanelState extends State<VideoReplyPanel>
                     } else {
                       // 请求错误
                       return HttpError(
-                        errMsg: data['msg'],
+                        errMsg: data?['msg'] ?? "网络不太好 请稍后再试",
                         fn: () {
                           setState(() {
                             _futureBuilderFuture =


### PR DESCRIPTION
I/flutter ( 9105): [2024-11-21 14:29:55.024187 | Catcher 2 | INFO] ---------- ERROR ----------
I/flutter ( 9105): [2024-11-21 14:29:55.025009 | Catcher 2 | INFO] A RenderViewport expected a child of type RenderSliver but received a child of type RenderErrorBox.
I/flutter ( 9105): RenderObjects expect specific types of children because they coordinate with their children during layout and paint. For example, a RenderSliver cannot be the child of a RenderBox because a RenderSliver does not understand the RenderBox layout protocol.
I/flutter ( 9105): 
I/flutter ( 9105): The RenderViewport that expected a RenderSliver child was created by:
I/flutter ( 9105):   Viewport ← IgnorePointer-[GlobalKey#56717] ← Semantics ← Listener ← _GestureSemantics ← RawGestureDetector-[LabeledGlobalKey<RawGestureDetectorState>#4bdea] ← Listener ← _ScrollableScope ← _ScrollSemantics-[GlobalKey#a2f4a] ← NotificationListener<ScrollMetricsNotification> ← Transform ← ClipRect ← ⋯
I/flutter ( 9105): 
I/flutter ( 9105): The RenderErrorBox that did not match the expected child type was created by:
I/flutter ( 9105):   ErrorWidget-[#fc8b5] ← FutureBuilder<dynamic> ← Viewport ← IgnorePointer-[GlobalKey#56717] ← Semantics ← Listener ← _GestureSema

--------------------------------------
if (_videoReplyController.replyList.isNotEmpty || (data && data['status'])) 这句代码由于data类型是Map 而不是bool 导致错误 返回ErrorRenderBox 与CustomScrollView需要的SliverRenderBox不一致 进而引发上述错误 该问题在ios上会直接导致页面无法响应手势 只能杀进程 当前flutter版本 3.24.5