### PR TITLE
fix: 排行榜数据修正 (rid变动), 移除"国创","生活"tab

### DIFF
--- a/lib/models/common/rank_type.dart
+++ b/lib/models/common/rank_type.dart
@@ -16,9 +16,7 @@ enum RandType {
   madness,
   fashion,
   entertainment,
-  film,
-  origin,
-  rookie
+  film
 }
 
 extension RankTypeDesc on RandType {
@@ -50,7 +48,6 @@ extension RankTypeDesc on RandType {
         'technology',
         'sport',
         'car',
-        'life',
         'food',
         'animal',
         'madness',

--- a/lib/models/common/rank_type.dart
+++ b/lib/models/common/rank_type.dart
@@ -3,7 +3,6 @@ import 'package:pilipala/pages/rank/zone/index.dart';
 
 enum RandType {
   all,
-  creation,
   animation,
   music,
   dance,
@@ -12,7 +11,6 @@ enum RandType {
   technology,
   sport,
   car,
-  life,
   food,
   animal,
   madness,
@@ -26,7 +24,6 @@ enum RandType {
 extension RankTypeDesc on RandType {
   String get description => [
         '全站',
-        '国创相关',
         '动画',
         '音乐',
         '舞蹈',
@@ -35,7 +32,6 @@ extension RankTypeDesc on RandType {
         '科技',
         '运动',
         '汽车',
-        '生活',
         '美食',
         '动物圈',
         '鬼畜',
@@ -46,7 +42,6 @@ extension RankTypeDesc on RandType {
 
   String get id => [
         'all',
-        'creation',
         'animation',
         'music',
         'dance',
@@ -80,18 +75,9 @@ List tabsConfig = [
       Icons.live_tv_outlined,
       size: 15,
     ),
-    'label': '国创相关',
-    'type': RandType.creation,
-    'page': const ZonePage(rid: 168),
-  },
-  {
-    'icon': const Icon(
-      Icons.live_tv_outlined,
-      size: 15,
-    ),
     'label': '动画',
     'type': RandType.animation,
-    'page': const ZonePage(rid: 1),
+    'page': const ZonePage(rid: 1005),
   },
   {
     'icon': const Icon(
@@ -100,7 +86,7 @@ List tabsConfig = [
     ),
     'label': '音乐',
     'type': RandType.music,
-    'page': const ZonePage(rid: 3),
+    'page': const ZonePage(rid: 1003),
   },
   {
     'icon': const Icon(
@@ -109,7 +95,7 @@ List tabsConfig = [
     ),
     'label': '舞蹈',
     'type': RandType.dance,
-    'page': const ZonePage(rid: 129),
+    'page': const ZonePage(rid: 1004),
   },
   {
     'icon': const Icon(
@@ -118,7 +104,7 @@ List tabsConfig = [
     ),
     'label': '游戏',
     'type': RandType.game,
-    'page': const ZonePage(rid: 4),
+    'page': const ZonePage(rid: 1008),
   },
   {
     'icon': const Icon(
@@ -127,7 +113,7 @@ List tabsConfig = [
     ),
     'label': '知识',
     'type': RandType.knowledge,
-    'page': const ZonePage(rid: 36),
+    'page': const ZonePage(rid: 1010),
   },
   {
     'icon': const Icon(
@@ -136,7 +122,7 @@ List tabsConfig = [
     ),
     'label': '科技',
     'type': RandType.technology,
-    'page': const ZonePage(rid: 188),
+    'page': const ZonePage(rid: 1012),
   },
   {
     'icon': const Icon(
@@ -145,7 +131,7 @@ List tabsConfig = [
     ),
     'label': '运动',
     'type': RandType.sport,
-    'page': const ZonePage(rid: 234),
+    'page': const ZonePage(rid: 1018),
   },
   {
     'icon': const Icon(
@@ -154,16 +140,7 @@ List tabsConfig = [
     ),
     'label': '汽车',
     'type': RandType.car,
-    'page': const ZonePage(rid: 223),
-  },
-  {
-    'icon': const Icon(
-      Icons.live_tv_outlined,
-      size: 15,
-    ),
-    'label': '生活',
-    'type': RandType.life,
-    'page': const ZonePage(rid: 160),
+    'page': const ZonePage(rid: 1013),
   },
   {
     'icon': const Icon(
@@ -172,7 +149,7 @@ List tabsConfig = [
     ),
     'label': '美食',
     'type': RandType.food,
-    'page': const ZonePage(rid: 211),
+    'page': const ZonePage(rid: 1020),
   },
   {
     'icon': const Icon(
@@ -181,7 +158,7 @@ List tabsConfig = [
     ),
     'label': '动物圈',
     'type': RandType.animal,
-    'page': const ZonePage(rid: 217),
+    'page': const ZonePage(rid: 1024),
   },
   {
     'icon': const Icon(
@@ -190,7 +167,7 @@ List tabsConfig = [
     ),
     'label': '鬼畜',
     'type': RandType.madness,
-    'page': const ZonePage(rid: 119),
+    'page': const ZonePage(rid: 1007),
   },
   {
     'icon': const Icon(
@@ -199,7 +176,7 @@ List tabsConfig = [
     ),
     'label': '时尚',
     'type': RandType.fashion,
-    'page': const ZonePage(rid: 155),
+    'page': const ZonePage(rid: 1014),
   },
   {
     'icon': const Icon(
@@ -208,7 +185,7 @@ List tabsConfig = [
     ),
     'label': '娱乐',
     'type': RandType.entertainment,
-    'page': const ZonePage(rid: 5),
+    'page': const ZonePage(rid: 1002),
   },
   {
     'icon': const Icon(
@@ -217,6 +194,6 @@ List tabsConfig = [
     ),
     'label': '影视',
     'type': RandType.film,
-    'page': const ZonePage(rid: 181),
+    'page': const ZonePage(rid: 1001),
   }
 ];


### PR DESCRIPTION
**描述 (Description):**

此 PR 解决了排行榜榜单列表数据长期未更新的问题，并移除了不再支持的 Tab。

**问题 (Problem):**

近期发现排行榜榜单列表数据长期显示旧日期的数据，未能获取到最新的榜单信息。

**原因 (Cause):**

经研究发现，用于获取排行榜数据的 `rid` 参数发生了变化，导致原有的接口调用无法获取到最新数据。

**解决方案与改动 (Solution & Changes):**

1.  更新了代码中使用的 `rid` 参数，使其与最新的接口要求匹配。
2.  移除了不再支持或已失效的 "国创" 和 "生活" Tab，以保持界面的整洁和功能的有效性。

**结果 (Result):**

现在可以成功获取并展示最新的排行榜数据。移除了无效 Tab 提升了用户体验和代码的可维护性。